### PR TITLE
Update usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please refer to the [wiki](https://github.com/karashiiro/node-machina-ffxiv/wiki
 ## Example
 ```
 const MachinaFFXIV = require('node-machina-ffxiv');
-const Machina = new MachinaFFXIV();
+const Machina = new MachinaFFXIV({}); // An object must be provided, even if it is empty.
 Machina.start(() => {
     console.log("Machina started!");
 });


### PR DESCRIPTION
An object must be provided to init MachinaFFXIV, even if it is empty. Otherwise default option, especially option.spawn would not be set, which will lead to an error like:
```
node-machina-ffxiv\node-machina-ffxiv.js:159
                this[monitor] = this[spawn](this[exePath], this[args]);
                                           ^

TypeError: this[spawn] is not a function
```